### PR TITLE
Fix output directory creation typo in scripts/prepare_data.sh

### DIFF
--- a/scripts/prepare_data.sh
+++ b/scripts/prepare_data.sh
@@ -3,7 +3,7 @@
 # Model used to select prompt
 model_name=Qwen/Qwen2.5-Math-1.5B
 output_dir="./data/openr1"
-mkdir -p $data_dir
+mkdir -p $output_dir
 
 # Configuration
 pass_rate=0.125


### PR DESCRIPTION
In scripts/prepare_data.sh, mkdir uses $data_dir as parameter, however, this should be output_dir
```bash
# Model used to select prompt
model_name=Qwen/Qwen2.5-Math-1.5B
output_dir="./data/openr1"
mkdir -p $data_dir
``` 

This PR fixed this problem