### PR TITLE
[Bug Fix]: Move seed setting after argument parsing

### DIFF
--- a/eval/gen_data.py
+++ b/eval/gen_data.py
@@ -70,14 +70,14 @@ class ScriptArguments:
 
 
 def main():
-    # set seed
-    torch.manual_seed(script_args.seed)
-    np.random.seed(script_args.seed)
-
     # Arguments
     parser = HfArgumentParser(ScriptArguments)
     script_args = parser.parse_args_into_dataclasses()[0]
     print("model_path", script_args.model_name_or_path)
+
+    # set seed
+    torch.manual_seed(script_args.seed)
+    np.random.seed(script_args.seed)
 
     # Load model and tokenizer
     llm = LLM(


### PR DESCRIPTION
In the script `eval/gen_data.py` , current code use script_args before its assignment, This will lead to bug. I changed the order to fix this bug.

original code
```python
def main():
    # set seed
    torch.manual_seed(script_args.seed)
    np.random.seed(script_args.seed)

    # Arguments
    parser = HfArgumentParser(ScriptArguments)
    script_args = parser.parse_args_into_dataclasses()[0]
    print("model_path", script_args.model_name_or_path)
```

After I fix
```python
def main():
    # Arguments
    parser = HfArgumentParser(ScriptArguments)
    script_args = parser.parse_args_into_dataclasses()[0]
    print("model_path", script_args.model_name_or_path)

    # set seed
    torch.manual_seed(script_args.seed)
    np.random.seed(script_args.seed)
```