### PR TITLE
Change score condition from sum to mean in prompt selection. 

### DIFF
--- a/data_process/prompt_selection.py
+++ b/data_process/prompt_selection.py
@@ -36,7 +36,7 @@ def main():
     # Prompt selection
     selected_prompts = []
     for sample in ds:
-        if np.sum(sample["scores"]) <= script_args.pass_rate and np.sum(sample["scores"]) > 0:
+        if np.mean(sample["scores"]) <= script_args.pass_rate and np.sum(sample["scores"]) > 0:
             selected_prompts.append(
                 {
                     "problem": sample["prompt"],


### PR DESCRIPTION
According to the Readme, the pass rate for selecting hard / easy prompt are 0.125 and 0.313 respectively. 

So I think it should be np.mean in prompt selection. This is because the reward is either 0 or 1. So here should be mean rather than sum